### PR TITLE
ft: Remote State

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -181,6 +181,7 @@ locals {
     "AWS Landing Zone" = {
       workspaces = {
         "AWS_OIDC_TerraformCloud" = {
+          remote_state_consumer_ids = ["ws-igXekzgees7Nt4QB"]
           notifications = {
             "MS_TEAM" = {
               destination_type = "microsoft-teams"
@@ -208,6 +209,9 @@ locals {
           }
         }
       }
+    }
+    "AWS Workloads" = {
+
     }
     "Terraform Cloud" = {
       workspaces = {


### PR DESCRIPTION
## Overview/Summary

Allow TerraformCloud_Foundation to read AWS_OIDC_TerraformCloud state.

## This PR fixes/adds/changes/removes

* *Add: remote_state_consumer_ids for AWS_OIDC_TerraformCloud.*
